### PR TITLE
nrf_security: Kconfig: Make MBEDTLS_RSA_C default n

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1261,7 +1261,7 @@ endif # MBEDTLS_ECP_C
 menuconfig MBEDTLS_RSA_C
 	bool
 	prompt "RSA   - Rivest–Shamir–Adleman cryptosystem"
-	default y
+	default n
 	select CC3XX_MBEDTLS_RSA_C if CC3XX_SINGLE_BACKEND
 	select VANILLA_MBEDTLS_RSA_C if OBERON_SINGLE_BACKEND || MBEDTLS_VANILLA_SINGLE_BACKEND
 	help


### PR DESCRIPTION
For the time being since it does not work properly.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>