### PR TITLE
nrf_security: Enable the CC3XX PSA driver by default

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -110,7 +110,6 @@ menu "Zephyr legacy configurations"
 
 config MBEDTLS_TLS_VERSION_1_2
 	bool "Enable support for TLS 1.2 (DTLS 1.2)"
-	default y if !NET_L2_OPENTHREAD
 	select PSA_WANT_ALG_SHA_1
 	select PSA_WANT_ALG_SHA_224
 	select PSA_WANT_ALG_SHA_256

--- a/nrf_security/src/drivers/Kconfig
+++ b/nrf_security/src/drivers/Kconfig
@@ -40,7 +40,7 @@ menuconfig PSA_CRYPTO_DRIVER_CC3XX
     bool
     prompt "PSA CryptoCell Driver" if !PSA_PROMPTLESS
     depends on CRYPTOCELL_USABLE
-    default n
+    default y
     select NRF_CC3XX_PLATFORM if !BUILD_WITH_TFM
 	help
 	  Enable PSA Driver for CryptoCell

--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -468,44 +468,14 @@ psa_status_t psa_driver_wrapper_verify_hash(
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #if defined(PSA_CRYPTO_DRIVER_OBERON)
-            {
-                /* Workaround NCSDK-13486
-                * oberon_verify_hash does not support PSA_KEY_TYPE_CATEGORY_KEY_PAIR.
-                * Export a key that is PSA_KEY_TYPE_CATEGORY_PUBLIC_KEY instead.
-                */
-                psa_key_attributes_t attributes_copy = *attributes;
-                psa_key_type_t key_type = psa_get_key_type(&attributes_copy);
-
-                size_t exported_length = 0;
-                uint8_t exported[PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(256)];
-
-                if (PSA_KEY_TYPE_IS_KEY_PAIR(key_type)) {
-                    mbedtls_svc_key_id_t key = psa_get_key_id(&attributes_copy);
-
-                    status = psa_export_public_key(key, exported, sizeof(exported),
-                                                &exported_length);
-                    if (status != PSA_SUCCESS) {
-                        return status;
-                    }
-
-                    key_type &= ~PSA_KEY_TYPE_CATEGORY_FLAG_PAIR;
-                    psa_set_key_type(&attributes_copy, key_type);
-
-                    key_buffer_size = exported_length;
-                    key_buffer = exported;
-
-                    attributes = &attributes_copy;
-                }
-
-                status = oberon_verify_hash( attributes,
-                                            key_buffer,
-                                            key_buffer_size,
-                                            alg,
-                                            hash,
-                                            hash_length,
-                                            signature,
-                                            signature_length);
-            }
+            status = oberon_verify_hash(attributes,
+                                        key_buffer,
+                                        key_buffer_size,
+                                        alg,
+                                        hash,
+                                        hash_length,
+                                        signature,
+                                        signature_length);
 
             /* Declared with fallback == true */
             if( status != PSA_ERROR_NOT_SUPPORTED )


### PR DESCRIPTION
-This enables the CC3XX PSA driver by default.
-To do that it also disables the TLS 1.2 version by default, since this will force
 the Oberon PSA driver to be enabled in CryptoCell 310 devices.

Ref: NCSDK-14720